### PR TITLE
Fix pdfjs import path

### DIFF
--- a/src/components/SceneImporter.jsx
+++ b/src/components/SceneImporter.jsx
@@ -1,6 +1,7 @@
+'use client';
 import React, { useState } from 'react';
 import { FileUp, Upload } from 'lucide-react';
-import { pdfjs } from 'pdfjs-dist';
+import * as pdfjs from 'pdfjs-dist/legacy/build/pdf';
 
 pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.js`;
 

--- a/src/components/ShootingRecorder.jsx
+++ b/src/components/ShootingRecorder.jsx
@@ -1,3 +1,4 @@
+'use client';
 import React, { useState } from 'react';
 import {
   Play,


### PR DESCRIPTION
## Summary
- make SceneImporter a client component
- make ShootingRecorder a client component
- correct the pdfjs import path
- fix pdfjs path to use legacy build

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68444e6e3cac83318ef3fc36535ceaca