### PR TITLE
Fix pdfjs import

### DIFF
--- a/src/components/SceneImporter.jsx
+++ b/src/components/SceneImporter.jsx
@@ -1,7 +1,7 @@
 'use client';
 import React, { useState } from 'react';
 import { FileUp, Upload } from 'lucide-react';
-import * as pdfjs from 'pdfjs-dist/legacy/build/pdf';
+import * as pdfjs from 'pdfjs-dist/legacy/build/pdf.js';
 
 pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.js`;
 


### PR DESCRIPTION
## Summary
- correct pdfjs import path

## Testing
- `npm test` *(fails: Missing script)*
- `npx next dev` *(fails: 403 Forbidden when fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_6844517d7fec8331afee2e4e3be5f6c8