### PR TITLE
Fix: remove completion alert

### DIFF
--- a/src/components/ShootingRecorder.jsx
+++ b/src/components/ShootingRecorder.jsx
@@ -109,10 +109,7 @@ const ShootingRecorder = () => {
         status: 'completed'
       };
 
-      // 撮影時間を計算して表示
-      const duration = calculateDuration(finalRecord.startTime, finalRecord.endTime, finalRecord.pausedDuration);
-      alert(`撮影完了！\nシーン: ${finalRecord.scene}\n撮影時間: ${duration}`);
-
+      // 撮影記録に追加
       setRecords(prevRecords => {
         console.log('Adding record:', finalRecord); // デバッグ用
         console.log('Previous records:', prevRecords); // デバッグ用


### PR DESCRIPTION
## Summary
- remove alert popup after stopping recording

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844628348d88331a1f9d00955fd0c01