### PR TITLE
Add data reset feature

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,24 @@
 import { useState, useEffect } from 'react'
-import { Play, Pause, Square, Plus, Download, Trash2, Clock, Camera } from 'lucide-react'
+import {
+  Play,
+  Pause,
+  Square,
+  Plus,
+  Download,
+  Trash2,
+  Clock,
+  Camera,
+  MoreVertical,
+  RotateCw,
+} from 'lucide-react'
 import { Button } from '@/components/ui/button.jsx'
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from '@/components/ui/dropdown-menu.jsx'
 import {
   AlertDialog,
   AlertDialogTrigger,
@@ -503,14 +521,40 @@ function App() {
               <Clock className="w-5 h-5 text-blue-600" />
               撮影記録
             </h2>
-            <Button
-              onClick={exportToCSV}
-              disabled={records.length === 0}
-              className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-all duration-200 hover:scale-105 disabled:opacity-50 disabled:cursor-not-allowed shadow-md"
-            >
-              <Download className="w-4 h-4 mr-2" />
-              CSV出力
-            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="outline" size="icon">
+                  <MoreVertical className="w-5 h-5" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onSelect={exportToCSV} disabled={records.length === 0}>
+                  <Download className="w-4 h-4 mr-2" />
+                  CSV出力
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <AlertDialog>
+                  <AlertDialogTrigger asChild>
+                    <DropdownMenuItem>
+                      <RotateCw className="w-4 h-4 mr-2" />
+                      初期化
+                    </DropdownMenuItem>
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>データを初期化しますか？</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        ローカルに保存された撮影記録をすべて削除します。元に戻すことはできません。
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>キャンセル</AlertDialogCancel>
+                      <AlertDialogAction onClick={resetApp} className="bg-red-600 text-white hover:bg-red-700">初期化</AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
 
           {records.length === 0 ? (
@@ -602,23 +646,6 @@ function App() {
         <div>
           v{APP_VERSION} - made by <span onClick={handleCreditTap}>Undone</span>
         </div>
-        <AlertDialog>
-          <AlertDialogTrigger asChild>
-            <Button variant="outline" size="sm">初期化</Button>
-          </AlertDialogTrigger>
-          <AlertDialogContent>
-            <AlertDialogHeader>
-              <AlertDialogTitle>データを初期化しますか？</AlertDialogTitle>
-              <AlertDialogDescription>
-                ローカルに保存された撮影記録をすべて削除します。元に戻すことはできません。
-              </AlertDialogDescription>
-            </AlertDialogHeader>
-            <AlertDialogFooter>
-              <AlertDialogCancel>キャンセル</AlertDialogCancel>
-              <AlertDialogAction onClick={resetApp} className="bg-red-600 text-white hover:bg-red-700">初期化</AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
         <span
           className={`absolute left-1/2 -translate-x-1/2 -top-2 text-pink-500 transition-opacity duration-700 ${showHearts ? 'opacity-100' : 'opacity-0'}`}
         >

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -66,6 +66,7 @@ function App() {
   const [customSceneName, setCustomSceneName] = useState('')
   const [creditTaps, setCreditTaps] = useState(0)
   const [showHearts, setShowHearts] = useState(false)
+  const [showResetDialog, setShowResetDialog] = useState(false)
 
   // ローカルストレージへの保存
   useEffect(() => {
@@ -308,6 +309,7 @@ function App() {
     setSelectedScene('')
     setIsRecording(false)
     setIsPaused(false)
+    setShowResetDialog(false)
   }
 
   return (
@@ -533,26 +535,10 @@ function App() {
                   CSV出力
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
-                <AlertDialog>
-                  <AlertDialogTrigger asChild>
-                    <DropdownMenuItem>
-                      <RotateCw className="w-4 h-4 mr-2" />
-                      初期化
-                    </DropdownMenuItem>
-                  </AlertDialogTrigger>
-                  <AlertDialogContent>
-                    <AlertDialogHeader>
-                      <AlertDialogTitle>データを初期化しますか？</AlertDialogTitle>
-                      <AlertDialogDescription>
-                        ローカルに保存された撮影記録をすべて削除します。元に戻すことはできません。
-                      </AlertDialogDescription>
-                    </AlertDialogHeader>
-                    <AlertDialogFooter>
-                      <AlertDialogCancel>キャンセル</AlertDialogCancel>
-                      <AlertDialogAction onClick={resetApp} className="bg-red-600 text-white hover:bg-red-700">初期化</AlertDialogAction>
-                    </AlertDialogFooter>
-                  </AlertDialogContent>
-                </AlertDialog>
+                <DropdownMenuItem onSelect={() => setShowResetDialog(true)}>
+                  <RotateCw className="w-4 h-4 mr-2" />
+                  初期化
+                </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
           </div>
@@ -652,6 +638,21 @@ function App() {
           {'\u2764\u2764\u2764\u2764\u2764'}
         </span>
       </footer>
+
+      <AlertDialog open={showResetDialog} onOpenChange={setShowResetDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>データを初期化しますか？</AlertDialogTitle>
+            <AlertDialogDescription>
+              シーン/撮影記録をすべて削除します。元に戻すことはできません。
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>キャンセル</AlertDialogCancel>
+            <AlertDialogAction onClick={resetApp} className="bg-red-600 text-white hover:bg-red-700">初期化</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,17 @@
 import { useState, useEffect } from 'react'
 import { Play, Pause, Square, Plus, Download, Trash2, Clock, Camera } from 'lucide-react'
 import { Button } from '@/components/ui/button.jsx'
+import {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+} from '@/components/ui/alert-dialog.jsx'
 import './App.css'
 
 const APP_VERSION = __APP_VERSION__
@@ -263,6 +274,22 @@ function App() {
       }
       return next
     })
+  }
+
+  const resetApp = () => {
+    localStorage.removeItem('shooting-app-scenes')
+    localStorage.removeItem('shooting-app-records')
+    localStorage.removeItem('shooting-app-current-record')
+    localStorage.removeItem('shooting-app-selected-scene')
+    localStorage.removeItem('shooting-app-is-recording')
+    localStorage.removeItem('shooting-app-is-paused')
+
+    setScenes(['サムネイル撮影', 'モノローグ'])
+    setRecords([])
+    setCurrentRecord(null)
+    setSelectedScene('')
+    setIsRecording(false)
+    setIsPaused(false)
   }
 
   return (
@@ -571,8 +598,27 @@ function App() {
           )}
         </div>
       </div>
-      <footer className="relative text-center text-xs text-slate-500 py-4">
-        v{APP_VERSION} - made by <span onClick={handleCreditTap}>Undone</span>
+      <footer className="relative text-center text-xs text-slate-500 py-4 space-y-2">
+        <div>
+          v{APP_VERSION} - made by <span onClick={handleCreditTap}>Undone</span>
+        </div>
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <Button variant="outline" size="sm">初期化</Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>データを初期化しますか？</AlertDialogTitle>
+              <AlertDialogDescription>
+                ローカルに保存された撮影記録をすべて削除します。元に戻すことはできません。
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>キャンセル</AlertDialogCancel>
+              <AlertDialogAction onClick={resetApp} className="bg-red-600 text-white hover:bg-red-700">初期化</AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
         <span
           className={`absolute left-1/2 -translate-x-1/2 -top-2 text-pink-500 transition-opacity duration-700 ${showHearts ? 'opacity-100' : 'opacity-0'}`}
         >

--- a/src/components/ui/button.jsx
+++ b/src/components/ui/button.jsx
@@ -35,21 +35,20 @@ const buttonVariants = cva(
   }
 )
 
-function Button({
-  className,
-  variant,
-  size,
-  asChild = false,
-  ...props
-}) {
-  const Comp = asChild ? Slot : "button"
+const Button = React.forwardRef(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button";
 
-  return (
-    <Comp
-      data-slot="button"
-      className={cn(buttonVariants({ variant, size, className }))}
-      {...props} />
-  );
-}
+    return (
+      <Comp
+        ref={ref}
+        data-slot="button"
+        className={cn(buttonVariants({ variant, size, className }))}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = "Button";
 
 export { Button, buttonVariants }


### PR DESCRIPTION
## Summary
- reset app state to initial values via `resetApp`
- add confirmation dialog for clearing local storage
- expose *初期化* button in footer

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684563e0cf8c8331aa50e88488e5b52c